### PR TITLE
remove raspberry pi 1 note

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,3 @@ This project installs Ruby which allows you to execute Ruby applications on [Res
 This is a very simple project that is an example of how to run Ruby code on a device that is supported by Resin.io. 
 
 You can build and deploy your code on the Raspberry Pi. Other versions of Ruby are also supported by [RVM](http://rvm.io/rubies).
-
-### Note for Raspberry pi 1
-If the device you are planning to use is a raspberry pi 1 you will have to modify Dockerfile.template in order to use the application.
-```
-FROM resin/%%RESIN_MACHINE_NAME%%-debian
-```
-To
-```
-FROM resin/%%RESIN_MACHINE_NAME%%-raspbian
-```


### PR DESCRIPTION
I just tested this out last night with a raspberry pi 1 and found that %%RESIN_MACHINE_NAME%%-raspbian resolves to raspberrypi-raspbian, which is not a valid docker image in resin.io's registry (https://hub.docker.com/r/resin/raspberrypi-raspbian/ results in a 404).

rpi-raspbian exists (https://hub.docker.com/r/resin/rpi-raspbian/), but that's not what the resin machine name resolves to for the raspberry pi 1 (which is consistent with: https://docs.resin.io/devicetypes/

raspberrypi-debian worked just fine so the note in the README is no longer applicable and could confuse someone trying this out for their first time.
